### PR TITLE
module: add Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ language: python
 python:
 - "2.7"
 - "3.4"
-- "3.5"
 - "3.7"
-- "3.8"
+- "3.9"
 
 install:
 - pip install poetry==1.0.10


### PR DESCRIPTION
- drop CI tests on Python <= 3.8 to save credits