### PR TITLE
ci: add GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+---
+name: ci
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+  schedule:
+  - cron: '37 4 * * 4'  # weekly on thursday morning
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+        - '2.7'
+        # Python 3.4 on GHA doesn't work due to fastdiff==0.2.0 failing with:
+        #   pkg_resources.DistributionNotFound: The 'setuptools_scm>=1.15.0' distribution was not found and is required by the application
+        #- '3.4'
+        - '3.5'
+        - '3.7'
+        - '3.9'
+    steps:
+    - uses: actions/checkout@v2
+    - run: python -m pip install --upgrade pip
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Poetry
+      run: |
+        pip install poetry==1.0.10
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Lint
+      run: |
+        make lint
+    - name: Test
+      run: |
+        make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@
 os: linux
 language: python
 python:
-- "2.7"
 - "3.4"
-- "3.7"
-- "3.9"
 
 install:
 - pip install poetry==1.0.10

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # python-veml6070
 
-[![Build Status](https://travis-ci.com/cmur2/python-veml6070.svg?branch=master)](https://travis-ci.com/cmur2/python-veml6070)
+![ci](https://github.com/cmur2/python-veml6070/workflows/ci/badge.svg?branch=master) [![Build Status](https://travis-ci.com/cmur2/python-veml6070.svg?branch=master)](https://travis-ci.com/cmur2/python-veml6070)
 
 A Python library for accessing the [VEML6070 digital UV light sensor](http://www.vishay.com/docs/84277/veml6070.pdf) from Vishay via `python-smbus` using the I2C interface.
 


### PR DESCRIPTION
- as Python 3.4 has problems on GHA we'll keep Travis for that while we still want to support 3.4